### PR TITLE
Example of "safety-net" pattern with commands

### DIFF
--- a/foo/bar.js
+++ b/foo/bar.js
@@ -1,0 +1,1 @@
+module.exports = () => console.log('.bar()')

--- a/foo/index.js
+++ b/foo/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+    bar: require('./bar')
+}

--- a/index.js
+++ b/index.js
@@ -1,27 +1,27 @@
+/*
+This is a proposal on how to achieve a safety net for modules that are removed from the app.
+If that is the case we want to know at start time that something is not correct.
 
-// // production code
-// const doMagic = require('./command/do-magic').doMagic
-// doMagic({color: 'magenta', message: 'You are one nice cow!'})
-//
-//
-//
-// // test code
-// const createDoMagicCommand = require('./command/do-magic').createDoMagicCommand
-//
-// const testDoMagic = createDoMagicCommand({
-//   chalk: require('chalk'),
-//   cowsay: {
-//     say({text}) {
-//       return `🐮  ${text}`
-//     }
-//   },
-//   log: console.log
-// })
-//
-// testDoMagic({color: 'blue', message: 'Test cows everywhere!'})
+It's easly achiavable with direct require of those modules and avoiding index.js:
+ */
 
 
-// throws an erro
-const doIndexMagic = require('./command')
+// production code
+const doMagic = require('./command/do-magic').doMagic
+doMagic({color: 'magenta', message: 'You are one nice cow!'})
 
-// doIndexMagic({color: 'cyan', message: 'You know what happens to cows when you use index.js files?'})
+
+// test code
+const createDoMagicCommand = require('./command/do-magic').createDoMagicCommand
+
+const testDoMagic = createDoMagicCommand({
+  chalk: require('chalk'),
+  cowsay: {
+    say({text}) {
+      return `🐮  ${text}`
+    }
+  },
+  log: console.log
+})
+
+testDoMagic({color: 'blue', message: 'Test cows everywhere!'})


### PR DESCRIPTION
Basic idea is to require commands directly and export both, command instance and the factory from the module. I so far see only few minor drawbacks:

* it's tempting to use dependencies directly when you have them available in same file (that's why I moved required below main command function in `do-magic.js`
* there is no "big picture" of what is going on in comparison to using one monolithic `index.js`